### PR TITLE
Cache Places photos to Cloud Storage to avoid API throttling

### DIFF
--- a/functions/src/lib/google/maps/photo_cache.ts
+++ b/functions/src/lib/google/maps/photo_cache.ts
@@ -1,0 +1,50 @@
+import * as admin from 'firebase-admin'
+import { PlacesApi } from './places_api'
+
+const BUCKET = 'dansguiden-b3a7d.appspot.com'
+
+export type PhotoSize = '256' | '1024'
+
+function extToContentType(ext: string): string {
+    if (ext === 'png') return 'image/png'
+    if (ext === 'webp') return 'image/webp'
+    return 'image/jpeg'
+}
+
+function contentTypeToExt(contentType: string | null): string {
+    if (!contentType) return 'jpg'
+    if (contentType.includes('png')) return 'png'
+    if (contentType.includes('webp')) return 'webp'
+    return 'jpg'
+}
+
+export class PhotoCache {
+    /**
+     * Download a Google Places photo and store it publicly in Cloud Storage.
+     * Returns the public Storage URL. Throws on download/upload failure so the
+     * caller can decide whether to fall through to a direct API URL.
+     *
+     * Storage path is deterministic on (placeId, size), so re-runs overwrite
+     * the same object and avoid orphaning blobs.
+     */
+    static async cache(apiKey: string, ref: string, placeId: string, size: PhotoSize): Promise<string> {
+        const url = PlacesApi.photoUrl(apiKey, ref, size)
+        const resp = await fetch(url)
+        if (!resp.ok) {
+            throw new Error(`Places photo download failed: ${resp.status} ${resp.statusText}`)
+        }
+        const buffer = Buffer.from(await resp.arrayBuffer())
+        const ext = contentTypeToExt(resp.headers.get('content-type'))
+        const contentType = extToContentType(ext)
+        const path = `media/places-api/${placeId}/${size}.${ext}`
+
+        const file = admin.storage().bucket(BUCKET).file(path)
+        await file.save(buffer, {
+            contentType,
+            metadata: { cacheControl: 'public, max-age=31536000, immutable' }
+        })
+        await file.makePublic()
+
+        return `https://storage.googleapis.com/${BUCKET}/${path}`
+    }
+}

--- a/functions/src/metadata_places.ts
+++ b/functions/src/metadata_places.ts
@@ -2,6 +2,7 @@ import { keyBy, omit, mapValues, pick, uniqBy, isUndefined, omitBy } from "lodas
 import { histogram } from "./lib/counter"
 import { PlacessParser } from "./lib/danslogen/places"
 import { PlacesApi } from "./lib/google/maps/places_api"
+import { PhotoCache } from "./lib/google/maps/photo_cache"
 import { DanceEvent } from "./lib/types"
 import { mergeWith } from "./lib/utils/utils"
 import { PlaceApiOverrides } from "./overrides"
@@ -97,12 +98,27 @@ function placesApiImage(secrets: PlacesSecerts): (values: DanceEvent[], existing
             if (first) {
                 const photo = first.photos?.find(() => true)
 
+                let photo_small: string | undefined
+                let photo_large: string | undefined
+                if (photo) {
+                    // Photos are cached to Cloud Storage so the public app does
+                    // not hit the Places API (which throttles + leaks the API
+                    // key). On failure we fall through to no photo and let the
+                    // client render its initials-avatar fallback.
+                    try {
+                        photo_small = await PhotoCache.cache(secrets.api_key, photo.photo_reference, first.place_id, '256')
+                        photo_large = await PhotoCache.cache(secrets.api_key, photo.photo_reference, first.place_id, '1024')
+                    } catch (err) {
+                        console.warn(`PhotoCache failed for ${place} (${first.place_id})`, err)
+                    }
+                }
+
                 const result = omitBy({
                     id: first.place_id,
                     name: first.name,
                     address: first.formatted_address,
-                    photo_small: photo ? PlacesApi.photoUrl(secrets.api_key, photo.photo_reference, '256') : undefined,
-                    photo_large: photo ? PlacesApi.photoUrl(secrets.api_key, photo.photo_reference, '1024') : undefined,
+                    photo_small,
+                    photo_large,
                     photo_attributions: photo ? photo.html_attributions : undefined
                 }, isUndefined) as PlacesApiInfo
 

--- a/functions/test/metadata.test.ts
+++ b/functions/test/metadata.test.ts
@@ -6,6 +6,7 @@ import { CollectionReference, DocumentReference, WriteBatch } from 'firebase-adm
 import { shuffle } from 'lodash'
 import moment from 'moment'
 import { PlacesApi } from '../src/lib/google/maps/places_api'
+import { PhotoCache } from '../src/lib/google/maps/photo_cache'
 
 type Col = CollectionReference
 type Doc = DocumentReference
@@ -85,6 +86,9 @@ describe('Metadata', () => {
     })
     jest.spyOn(Bands, 'getArtist').mockImplementation(async () => {
       return undefined
+    })
+    jest.spyOn(PhotoCache, 'cache').mockImplementation(async (_apiKey, _ref, placeId, size) => {
+      return `https://storage.googleapis.com/dansguiden-b3a7d.appspot.com/media/places-api/${placeId}/${size}.jpg`
     })
   })
 
@@ -170,8 +174,8 @@ describe('Metadata', () => {
           name: "place1",
           address: "adr1",
           photo_attributions: ["attr1"],
-          photo_large: "https://places.googleapis.com/v1/ref1/media?maxHeight=1024&maxWidth=1024&key=",
-          photo_small: "https://places.googleapis.com/v1/ref1/media?maxHeight=256&maxWidth=256&key="
+          photo_large: "https://storage.googleapis.com/dansguiden-b3a7d.appspot.com/media/places-api/123/1024.jpg",
+          photo_small: "https://storage.googleapis.com/dansguiden-b3a7d.appspot.com/media/places-api/123/256.jpg"
         }
       })
     })
@@ -190,8 +194,8 @@ describe('Metadata', () => {
           name: "place1",
           address: "adr1",
           photo_attributions: ["attr1"],
-          photo_large: "https://places.googleapis.com/v1/ref1/media?maxHeight=1024&maxWidth=1024&key=",
-          photo_small: "https://places.googleapis.com/v1/ref1/media?maxHeight=256&maxWidth=256&key="
+          photo_large: "https://storage.googleapis.com/dansguiden-b3a7d.appspot.com/media/places-api/123/1024.jpg",
+          photo_small: "https://storage.googleapis.com/dansguiden-b3a7d.appspot.com/media/places-api/123/256.jpg"
         }
       })
     })


### PR DESCRIPTION
## Summary

- Places photo URLs were stored as direct Google Places API endpoints (`https://places.googleapis.com/v1/<ref>/media?...&key=<API_KEY>`). Two problems: every client view counted against the daily Places quota (causing the throttled / broken images visible in the app), and the API key was leaked in public Firestore documents.
- New `PhotoCache.cache()` downloads each photo once during the weekly metadata refresh and stores it under `media/places-api/<place_id>/<size>.<ext>` in the existing app-default bucket (`dansguiden-b3a7d.appspot.com`), then writes the public Storage URL into the `metadata_places.places_api` document. Same pattern as the existing manual `overrides.ts` entries — just automated for the API-driven path.
- Cache failures are logged and the photo is omitted from metadata, so the client falls through to its initials-avatar fallback rather than blocking the metadata batch.

## Why Storage instead of an HTTP proxy

`firebase.json` has a pre-existing `/api/images` rewrite to a never-implemented `imagesFetch` function, but a Storage-backed solution is simpler:
- No proxy function to keep alive (and bill on every cache miss)
- Storage URLs are already CDN-cached by GCS, no `Cache-Control` tuning required
- Matches the established pattern in `functions/src/overrides.ts` and `scripts/image_upload.ts`
- API key never leaves the function

## Migration notes

- Existing Firestore documents keep their old (throttled) URLs until the place is re-processed. The weekly job currently skips places that already exist (`existingKeys`), so backfill is gradual; if you want to force-migrate everything at once, manually clear `metadata_places` or temporarily disable the `existingKeys` check.
- Storage paths are deterministic on `(place_id, size)`, so re-runs overwrite the same object — no orphaned blobs.

## Companion change

Frontend fallback so any image that still fails (old data, network error, etc.) renders gracefully: `tkhduracell/ion_dansguiden#5`.

## Test plan

- [x] `jest test/metadata.test.ts` — passes (mocks `PhotoCache.cache` and asserts new URL format)
- [x] `tsc --noEmit` — clean
- [x] `eslint` — clean
- [ ] Manual: trigger `metadataPlaces` once after deploy and confirm the bucket path + public URLs render in the app


---
_Generated by [Claude Code](https://claude.ai/code/session_01XYMpwfGYRdQx9KrH99yMuN)_